### PR TITLE
Optimize rendering

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -4,7 +4,7 @@ import {
     Marker,
 } from '../src';
 
-const map = L.map('map', {
+const map = window['map'] = L.map('map', {
     center: [54.980156831455, 82.897440725094],
     zoom: 15,
 });

--- a/src/CanvasRenderer.ts
+++ b/src/CanvasRenderer.ts
@@ -60,7 +60,24 @@ export class CanvasRenderer implements IRenderer {
 
     public onAddToMap(map: L.Map) {
         this._map = map;
-        const mapSize = map.getSize();
+        this.invalidateSize();
+    }
+
+    public onRemoveFromMap() {
+        this._map = undefined;
+    }
+
+    public clear() {
+        this._ctx.clearRect(0, 0, this._size[0] * this._pixelRatio, this._size[1] * this._pixelRatio);
+        this._tree.clear();
+    }
+
+    public invalidateSize() {
+        if (!this._map) {
+            return;
+        }
+
+        const mapSize = this._map.getSize();
         this._pixelRatio = window.devicePixelRatio;
 
         this._bufferOffset = [
@@ -76,15 +93,6 @@ export class CanvasRenderer implements IRenderer {
         this.container.height = size[1] * this._pixelRatio;
         this.container.style.width = size[0] + 'px';
         this.container.style.height = size[1] + 'px';
-    }
-
-    public onRemoveFromMap() {
-        this._map = undefined;
-    }
-
-    public clear() {
-        this._ctx.clearRect(0, 0, this._size[0] * this._pixelRatio, this._size[1] * this._pixelRatio);
-        this._tree.clear();
     }
 
     public update() {

--- a/src/MarkerDrawer.ts
+++ b/src/MarkerDrawer.ts
@@ -78,6 +78,7 @@ export class MarkerDrawer extends L.Layer {
             moveend: this._update,
             zoomstart: this._onZoomStart,
             click: this._onClick,
+            resize: this._onResize,
         };
     }
 
@@ -107,5 +108,9 @@ export class MarkerDrawer extends L.Layer {
         if (markers.length) {
             this.fire('click', { markers });
         }
+    }
+
+    private _onResize() {
+        this._renderer.invalidateSize();
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,5 @@ export interface IRenderer {
     clear();
     search(point: L.Point);
     update();
+    invalidateSize();
 }


### PR DESCRIPTION
* Теперь рендеринг происходит не за 1 кадр, а за несколько, за счет этого рендер луп не забивается отрисовкой
* Чтобы маркера не мелькали, сделал два канваса, один показывается пользователю, на другом скрыто происходит рендеринг
* Количество маркеров отрисовывающихся в конкретный фрейм считается адаптивно, так чтобы это не длилось больше 10ms

Остальное:
* Убрал методы `setMarkerIcon`, `setMarkersIcon`, если нужно поменять иконку маркера, то надо поменять `iconIndex` у объекта маркера и вызвать `markerDrawer.update()`
* Добавил метод `setMarkers`, чтобы менять весь массив рисующихся маркеров
