### PR TITLE
Crutch for ie11

### DIFF
--- a/src/Atlas.ts
+++ b/src/Atlas.ts
@@ -1,5 +1,6 @@
 import * as pack from 'bin-pack';
 import { Vec2 } from './types';
+import { parseImageSource } from './utils';
 
 /**
  * Icon with options for atlas
@@ -60,6 +61,14 @@ export class Atlas {
         const margin = 2;
 
         const arr: any = icons.map((icon) => {
+
+            // Crutch for IE in case of SVG image
+            if (!icon.image.width || !icon.image.height) {
+                const parsedSize = parseImageSource(icon.image);
+                icon.image.width = parsedSize[0];
+                icon.image.height = parsedSize[1];
+            }
+
             const imageSize = [icon.image.width, icon.image.height];
             const size = icon.size || imageSize;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,8 +41,10 @@ export function parseImageSource(image: HTMLImageElement) {
     const widthExp = /width=['|"](\w+)['|"]/;
     const heightExp = /height=['|"](\w+)['|"]/;
     const width = isBase64 ?
+    // @ts-ignore: Object is possibly 'null'
         parseFloat(atob(src.split('base64,')[1].trim()).match(widthExp)[1]) : parseFloat(src.match(widthExp)[1]);
     const height = isBase64 ?
+    // @ts-ignore: Object is possibly 'null'
         parseFloat(atob(src.split('base64,')[1].trim()).match(heightExp)[1]) : parseFloat(src.match(heightExp)[1]);
     return [isNaN(width) ? 0 : width, isNaN(height) ? 0 : height];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,15 @@ function latLngToMapPoint(out: Vec2, lngLat: LngLat) {
 export const now = window.performance && window.performance.now
     ? performance.now.bind(performance)
     : Date.now.bind(Date);
+
+export function parseImageSource(image: HTMLImageElement) {
+    const src = image.src;
+    const isBase64 = src.indexOf('base64') !== -1;
+    const widthExp = /width=['|"](\w+)['|"]/;
+    const heightExp = /height=['|"](\w+)['|"]/;
+    const width = isBase64 ?
+        parseFloat(atob(src.split('base64,')[1].trim()).match(widthExp)[1]) : parseFloat(src.match(widthExp)[1]);
+    const height = isBase64 ?
+        parseFloat(atob(src.split('base64,')[1].trim()).match(heightExp)[1]) : parseFloat(src.match(heightExp)[1]);
+    return [isNaN(width) ? 0 : width, isNaN(height) ? 0 : height];
+}


### PR DESCRIPTION
Поскольку IE не понимает размеры image по src, то свойства width и height будут равны нулю. Для дальнейшей передачи этих значений в функцию drawImage() их необходимо получить путем распарсивания src, т.к. данной функции необходимы точные размеры исходного изображения, а при передаче нулевых значений будет выдаваться ошибка indexSizeError. 